### PR TITLE
Added support for 'avif' and 'jp2' formats

### DIFF
--- a/src/assets/javascripts/features/webspeedtest/components/ResultsItem/ImageInfo/ImageInfo.js
+++ b/src/assets/javascripts/features/webspeedtest/components/ResultsItem/ImageInfo/ImageInfo.js
@@ -60,6 +60,12 @@ export default class ImageInfo extends Component {
       case 'webp':
         browsers = ['Google Chrome', 'Opera'];
         break;
+      case 'avif':
+        browsers = ['Google Chrome', 'Firefox', 'Opera'];
+        break;
+      case 'jp2':
+        browsers = ['Google Chrome', 'Firefox', 'Opera'];
+        break;
 
       default:
         browsers = ['Google Chrome', 'Microsoft Edge', 'Firefox', 'Internet Explorer', 'Opera', 'Safari'];

--- a/src/assets/javascripts/translations/translations.js
+++ b/src/assets/javascripts/translations/translations.js
@@ -107,6 +107,8 @@ export const translations = {
     'svg': 'SVG',
     'wdp': 'JPEG-XR',
     'hdp': 'JPEG-XR',
+    'avif': 'AVIF',
+    'jp2': 'JPEG2000',
 
     // Loader
     // Loader configuration (time between sentences and loop yes/no) can be found in
@@ -132,7 +134,7 @@ export const translations = {
     'loaderWPTExplanation': `Website Speed Test is an image analysis tool that provides detailed optimization insights on how changes to image size, format, quality and encoding parameters can improve performance.
 
     Analysis may take 30 seconds.`,
-      
+
     // Meta data - homepahe
     'meta_title': 'Website Speed Test - Image Analysis Tool by Cloudinary',
     'meta_social_title': 'Website Speed Test - Image Analysis Tool by Cloudinary',


### PR DESCRIPTION
The Cloudinary service has added support for both jp2 and avif.
This PR adds support for both as possible variants on each WPT page analysis (Client).